### PR TITLE
がん保険レイアウト削除、承認番号追加、テキスト修正、ogp削除

### DIFF
--- a/src/template/index.html
+++ b/src/template/index.html
@@ -12,7 +12,6 @@
     <meta content="保険コンサルティング実績200万件突破！総合保険代理店フィナンシャル・エージェンシーがあなたにピッタリな保険プランをご提案いたします。" property="og:site_name" />
     <meta content="保険コンサルティング実績200万件突破！総合保険代理店フィナンシャル・エージェンシーがあなたにピッタリな保険プランをご提案いたします。" property="og:title" />
     <meta content="website" property="og:type" />
-    <meta content="images/og-image.png" property="og:image" />
     <meta content="ja_JP" property="og:locale" />
     <!-- favicon -->
     <link rel="shortcut icon" href="images/favicon.ico" />

--- a/src/template/index.html
+++ b/src/template/index.html
@@ -846,6 +846,226 @@
             <p class="c-detail-attention js-scroll-in">※1 調査には、治療費・食事代・差額ベッド代に加え、交通費（見舞いに来る家族の交通費を含む）や衣類、日用品などを含む。高額療養費制度を利用した場合は利用後の金額</p>
           </div>
         </section>
+        <!-- 社内確認が取れ次第、ページに反映する -->
+        <!-- <section class="l-gan-hoken">
+          <div class="c-section-heading js-scroll-in">
+            <p class="c-section-heading__text">がん保険のピッタリは？</p>
+            <div class="c-section-heading__line"></div>
+            <div class="c-section-heading__arrow"></div>
+          </div>
+          <div class="c-detail-button c-detail-button--gan js-scroll-in">
+            <div class="c-detail-button__box">
+              <p class="c-detail-button__box-text">がん保険って必要</p>
+            </div>
+          </div>
+          <div class="l-gan-hoken__illust js-scroll-in">
+            <picture>
+              <source srcset="images/webp/illust_gan_person.webp" type="image/webp" width="292" height="239" />
+              <img src="images/illust_gan_person.png" alt="がん保険って必要男性女性イラスト" width="292" height="239" loading="lazy" />
+            </picture>
+          </div>
+          <div class="l-detail-content l-gan-hoken__detail">
+            <div class="l-detail-content__arrow"></div>
+            <div class="l-detail-content__outer">
+              <div class="l-detail-content__inner">
+                <p class="c-detail__heading js-scroll-in">
+                  <span class="c-detail__heading-strong">2人に1人</span>が一生涯のうちに<br />
+                  「がん」と診断されています！
+                </p>
+                <div class="l-gan-data">
+                  <div class="l-gan-data__person-wrapper">
+                    <div class="l-gan-data__person l-gan-data__person--man js-anim">
+                      <div class="l-gan-data__person-illust">
+                        <div class="l-gan-data__person-illust-base">
+                          <picture>
+                            <source srcset="images/webp/illust_man_base.webp" type="image/webp" width="133" height="355" />
+                            <img src="images/illust_man_base.png" alt="がん率男性イラスト" width="133" height="355" loading="lazy" />
+                          </picture>
+                        </div>
+                        <div class="l-gan-data__person-illust-cover">
+                          <picture>
+                            <source srcset="images/webp/illust_man_cover.webp" type="image/webp" width="133" height="233" />
+                            <img src="images/illust_man_cover.png" alt="がん率男性イラスト" width="133" height="233" loading="lazy" />
+                          </picture>
+                        </div>
+                      </div>
+                      <p class="l-gan-data__person-rate l-gan-data__person-rate--man"><span class="font-roboto">65.5</span><span class="l-gan-data__person-rate-value">%</span></p>
+                    </div>
+                    <div class="l-gan-data__person l-gan-data__person--woman js-anim">
+                      <div class="l-gan-data__person-illust">
+                        <div class="l-gan-data__person-illust-base">
+                          <picture>
+                            <source srcset="images/webp/illust_woman_base.webp" type="image/webp" width="164" height="357" />
+                            <img src="images/illust_woman_base.png" alt="がん率女性イラスト本体" width="164" height="357" loading="lazy" />
+                          </picture>
+                        </div>
+                        <div class="l-gan-data__person-illust-cover">
+                          <picture>
+                            <source srcset="images/webp/illust_woman_cover.webp" type="image/webp" width="164" height="184" />
+                            <img src="images/illust_woman_cover.png" alt="がん率男性イラスト割合" width="164" height="184" loading="lazy" />
+                          </picture>
+                        </div>
+                      </div>
+                      <p class="l-gan-data__person-rate l-gan-data__person-rate--woman"><span class="font-roboto">51.2</span><span class="l-gan-data__person-rate-value">%</span></p>
+                    </div>
+                  </div>
+                  <p class="c-detail-attention js-scroll-in">(公財)がん研究振興財団｢がんの統計2023｣年齢階級別罹患リスク(2019年罹患・死亡データに基づく)全がん</p>
+                </div>
+                <p class="c-detail__heading js-scroll-in">がんの治療方法は<span class="c-detail__heading-strong">多様化</span></p>
+                <div class="l-gan-howto js-scroll-in">
+                  <p class="l-gan-howto__heading">がんの三大治療</p>
+                  <ul class="l-gan-howto__list">
+                    <li class="l-gan-howto__list-image">
+                      <picture>
+                        <source srcset="images/webp/illust_koganzai.webp" type="image/webp" width="150" height="150" />
+                        <img src="images/illust_koganzai.png" alt="抗がん剤" width="150" height="150" loading="lazy" />
+                      </picture>
+                    </li>
+                    <li class="l-gan-howto__list-image">
+                      <picture>
+                        <source srcset="images/webp/illust_hoshasen.webp" type="image/webp" width="150" height="150" />
+                        <img src="images/illust_hoshasen.png" alt="放射線" width="150" height="150" loading="lazy" />
+                      </picture>
+                    </li>
+                    <li class="l-gan-howto__list-image">
+                      <picture>
+                        <source srcset="images/webp/illust_shujyutsu.webp" type="image/webp" width="150" height="150" />
+                        <img src="images/illust_shujyutsu.png" alt="放射線" width="150" height="150" loading="lazy" />
+                      </picture>
+                    </li>
+                  </ul>
+                </div>
+                <div class="c-detail-arrow js-scroll-in">
+                  <picture>
+                    <source srcset="images/webp/icon_arrow_blue.webp" type="image/webp" width="320" height="70" />
+                    <img src="images/icon_arrow_blue.png" alt="下向き矢印" width="320" height="70" loading="lazy" />
+                  </picture>
+                </div>
+                <p class="c-detail__heading js-scroll-in">
+                  治療方法に縛られず<br />
+                  <span class="c-detail__heading-strong">使い方自由</span>な一時金
+                </p>
+                <div class="l-money js-scroll-in">
+                  <div class="l-money__figure">
+                    <div class="l-money__figure-track">
+                      <div class="l-money__figure-track-illust">
+                        <picture>
+                          <source srcset="images/webp/illust_track.webp" type="image/webp" width="594" height="270" />
+                          <img src="images/illust_track.png" alt="一時金のサイクル図" width="594" height="270" loading="lazy" />
+                        </picture>
+                      </div>
+                      <div class="l-money__figure-track-arrow l-money__figure-track-arrow--top">
+                        <div class="l-money__figure-track-arrow-elm l-money__figure-track-arrow-elm--top">
+                          <picture>
+                            <source srcset="images/webp/icon_arrow_top.webp" type="image/webp" width="53" height="64" />
+                            <img src="images/icon_arrow_top.png" alt="右向き矢印" width="53" height="64" loading="lazy" />
+                          </picture>
+                        </div>
+                        <div class="l-money__figure-track-arrow-elm l-money__figure-track-arrow-elm--top">
+                          <picture>
+                            <source srcset="images/webp/icon_arrow_top.webp" type="image/webp" width="53" height="64" />
+                            <img src="images/icon_arrow_top.png" alt="右向き矢印" width="53" height="64" loading="lazy" />
+                          </picture>
+                        </div>
+                      </div>
+                      <div class="l-money__figure-track-arrow l-money__figure-track-arrow--bottom">
+                        <div class="l-money__figure-track-arrow-elm l-money__figure-track-arrow-elm--bottom">
+                          <picture>
+                            <source srcset="images/webp/icon_arrow_btm.webp" type="image/webp" width="53" height="49" />
+                            <img src="images/icon_arrow_btm.png" alt="右向き矢印" width="53" height="49" loading="lazy" />
+                          </picture>
+                        </div>
+                        <div class="l-money__figure-track-arrow-elm l-money__figure-track-arrow-elm--bottom">
+                          <picture>
+                            <source srcset="images/webp/icon_arrow_btm.webp" type="image/webp" width="53" height="49" />
+                            <img src="images/icon_arrow_btm.png" alt="右向き矢印" width="53" height="49" loading="lazy" />
+                          </picture>
+                        </div>
+                      </div>
+                    </div>
+                    <div class="l-money__headline">
+                      <div class="l-money__headline-icon">
+                        <p class="l-money__headline-icon-pop">
+                          <picture>
+                            <source srcset="images/webp/pop_money.webp" type="image/webp" width="174" height="80" />
+                            <img src="images/pop_money.png" alt="100万円" width="174" height="80" loading="lazy" />
+                          </picture>
+                        </p>
+                        <div class="l-money__headline-icon-image">
+                          <picture>
+                            <source srcset="images/webp/illust_money.webp" type="image/webp" width="101" height="106" />
+                            <img src="images/illust_money.png" alt="お金のアイコン" width="101" height="106" loading="lazy" />
+                          </picture>
+                        </div>
+                      </div>
+                      <p class="l-money__headline-heading">
+                        繰り返し<br />
+                        <span class="l-money__headline-heading-color">何度</span>も受け取り!<sup class="l-gan-money__headline-heading-mark">*</sup>
+                      </p>
+                    </div>
+                  </div>
+                </div>
+                <p class="c-detail-attention js-scroll-in">＊ご案内する商品によって繰り返しもらえる回数や受取期間は異なります。申込みの際にご確認ください。</p>
+                <div class="l-gan-tsuin">
+                  <p class="l-gan__tsuin-heading js-scroll-in">さらに</p>
+                  <div class="l-gan-tsuin__inner">
+                    <p class="c-detail__heading js-scroll-in">
+                      がん治療は<br />
+                      <span class="c-detail__heading-strong">通院</span>が増えています！
+                    </p>
+                    <div class="l-line-graph">
+                      <div class="l-line-graph__figure">
+                        <div class="l-line-graph__base">
+                          <picture>
+                            <source srcset="images/webp/graph_line.webp" type="image/webp" width="568" height="381" />
+                            <img src="images/graph_line.png" alt="社会医療診療行為別統計(各年6月審査分)の折れ線グラフ" width="568" height="381" />
+                          </picture>
+                        </div>
+                        <div class="l-line-graph__rate js-anim">
+                          <div class="l-line-graph__rate-circle l-line-graph__rate-circle--circle1"></div>
+                          <div class="l-line-graph__rate-line l-line-graph__rate-line--long l-line-graph__rate-line--line1"></div>
+                          <div class="l-line-graph__rate-circle l-line-graph__rate-circle--circle2"></div>
+                          <div class="l-line-graph__rate-line l-line-graph__rate-line--line2"></div>
+                          <div class="l-line-graph__rate-circle l-line-graph__rate-circle--circle3"></div>
+                          <div class="l-line-graph__rate-line l-line-graph__rate-line--line3"></div>
+                          <div class="l-line-graph__rate-circle l-line-graph__rate-circle--circle4"></div>
+                          <div class="l-line-graph__rate-line l-line-graph__rate-line--line4"></div>
+                          <div class="l-line-graph__rate-circle l-line-graph__rate-circle--circle5"></div>
+                          <div class="l-line-graph__rate-line l-line-graph__rate-line--line5"></div>
+                          <div class="l-line-graph__rate-circle l-line-graph__rate-circle--circle6"></div>
+                          <div class="l-line-graph__rate-line l-line-graph__rate-line--line6"></div>
+                          <div class="l-line-graph__rate-circle l-line-graph__rate-circle--circle7"></div>
+                          <div class="l-line-graph__rate-line l-line-graph__rate-line--line7"></div>
+                        </div>
+                      </div>
+                      <p class="c-detail-attention c-detail-attention--line-graph">社会医療診療行為別統計(各年6月審査分)</p>
+                    </div>
+                    <div class="c-detail-arrow js-scroll-in">
+                      <picture>
+                        <source srcset="images/webp/icon_arrow_blue.webp" type="image/webp" width="320" height="70" />
+                        <img src="images/icon_arrow_blue.png" alt="下向き矢印" width="320" height="70" loading="lazy" />
+                      </picture>
+                    </div>
+                    <p class="c-detail__heading js-scroll-in">
+                      がん治療の<span class="c-detail__heading-strong">長期化</span>に備え<br />
+                      治療した月ごとの備えを*
+                    </p>
+                    <div class="l-term">
+                      <div class="l-term__figure js-scroll-in">
+                        <picture>
+                          <source srcset="images/webp/graph_term.webp" type="image/webp" width="645" height="281" />
+                          <img src="images/graph_term.png" alt="治療の流れのグラフ" width="645" height="281" />
+                        </picture>
+                      </div>
+                      <p class="c-detail-attention js-scroll-in">＊ご案内する商品・プランによって繰り返しもらえる回数や金額、対象となる治療方法が異なります。申込みの際にご確認ください。</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section> -->
+        <!-- /社内確認が取れ次第、ページに反映する -->
         <section class="l-interview">
           <div class="c-section-heading js-scroll-in">
             <p class="c-section-heading__text">オンライン面談の手順</p>

--- a/src/template/index.html
+++ b/src/template/index.html
@@ -613,8 +613,8 @@
                   </div>
                 </div>
                 <p class="c-detail-attention c-detail-attention--right js-scroll-in">
-                  厚生労働省令和2年｢患者調査 入院日数の分布｣より試算<br />
-                  (全ての病床)
+                  厚生労働省令和5年｢退院患者の平均在院日数等｣より<br />
+                  (一般病床)
                 </p>
                 <div class="c-detail-arrow js-scroll-in">
                   <picture>
@@ -640,10 +640,10 @@
                   <li class="l-support__col">
                     <div class="l-support__col-box">
                       <p class="l-support__col-box-price l-support__col-box-price--left">
-                        <span class="l-support__col-box-price-inner"> <span class="l-support__col-box-price-strong font-roboto">1</span>万円 </span>
+                        <span class="l-support__col-box-price-inner"> <span class="l-support__col-box-price-strong font-roboto">1</span>万円</span>
                       </p>
                       <p class="l-support__col-box-price l-support__col-box-price--right l-support__col-box-price--red">
-                        <span class="l-support__col-box-price-inner"> <span class="l-support__col-box-price-strong font-roboto">20</span>万円 </span>
+                        <span class="l-support__col-box-price-inner"> <span class="l-support__col-box-price-strong font-roboto">20</span>万円</span>
                       </p>
                     </div>
                     <div class="l-support__col-term">
@@ -662,10 +662,10 @@
                   <li class="l-support__col">
                     <div class="l-support__col-box">
                       <p class="l-support__col-box-price l-support__col-box-price--left">
-                        <span class="l-support__col-box-price-inner l-support__col-box-price-inner--left"> <span class="l-support__col-box-price-strong font-roboto">10</span>万円 </span>
+                        <span class="l-support__col-box-price-inner l-support__col-box-price-inner--left"> <span class="l-support__col-box-price-strong font-roboto">10</span>万円</span>
                       </p>
                       <p class="l-support__col-box-price l-support__col-box-price--right l-support__col-box-price--red">
-                        <span class="l-support__col-box-price-inner"> <span class="l-support__col-box-price-strong font-roboto">20</span>万円 </span>
+                        <span class="l-support__col-box-price-inner"> <span class="l-support__col-box-price-strong font-roboto">20</span>万円</span>
                       </p>
                     </div>
                     <div class="l-support__col-term">
@@ -684,10 +684,10 @@
                   <li class="l-support__col">
                     <div class="l-support__col-box">
                       <p class="l-support__col-box-price l-support__col-box-price--left l-support__col-box-price--last">
-                        <span class="l-support__col-box-price-inner l-support__col-box-price-inner--left"> <span class="l-support__col-box-price-strong font-roboto">14</span>万円 </span>
+                        <span class="l-support__col-box-price-inner l-support__col-box-price-inner--left"> <span class="l-support__col-box-price-strong font-roboto">14</span>万円</span>
                       </p>
                       <p class="l-support__col-box-price l-support__col-box-price--right l-support__col-box-price--last l-support__col-box-price--red">
-                        <span class="l-support__col-box-price-inner"> <span class="l-support__col-box-price-strong font-roboto">20</span>万円 </span>
+                        <span class="l-support__col-box-price-inner"> <span class="l-support__col-box-price-strong font-roboto">20</span>万円</span>
                       </p>
                     </div>
                     <div class="l-support__col-term">
@@ -800,10 +800,10 @@
                   <li class="l-support__col">
                     <div class="l-support__col-box">
                       <p class="l-support__col-box-price l-support__col-box-price--left">
-                        <span class="l-support__col-box-price-inner l-support__col-box-price-inner--left"> <span class="l-support__col-box-price-strong font-roboto">10</span>万円 </span>
+                        <span class="l-support__col-box-price-inner l-support__col-box-price-inner--left"> <span class="l-support__col-box-price-strong font-roboto">10</span>万円</span>
                       </p>
                       <p class="l-support__col-box-price l-support__col-box-price--right l-support__col-box-price--red">
-                        <span class="l-support__col-box-price-inner"> <span class="l-support__col-box-price-strong font-roboto">20</span>万円 </span>
+                        <span class="l-support__col-box-price-inner"> <span class="l-support__col-box-price-strong font-roboto">20</span>万円</span>
                       </p>
                     </div>
                     <div class="l-support__col-term">
@@ -822,10 +822,10 @@
                   <li class="l-support__col">
                     <div class="l-support__col-box">
                       <p class="l-support__col-box-price l-support__col-box-price--left l-support__col-box-price--last">
-                        <span class="l-support__col-box-price-inner l-support__col-box-price-inner--left"> <span class="l-support__col-box-price-strong font-roboto">14</span>万円 </span>
+                        <span class="l-support__col-box-price-inner l-support__col-box-price-inner--left"> <span class="l-support__col-box-price-strong font-roboto">14</span>万円</span>
                       </p>
                       <p class="l-support__col-box-price l-support__col-box-price--right l-support__col-box-price--last l-support__col-box-price--red">
-                        <span class="l-support__col-box-price-inner"> <span class="l-support__col-box-price-strong font-roboto">20</span>万円 </span>
+                        <span class="l-support__col-box-price-inner"> <span class="l-support__col-box-price-strong font-roboto">20</span>万円</span>
                       </p>
                     </div>
                     <div class="l-support__col-term">
@@ -847,226 +847,6 @@
             <p class="c-detail-attention js-scroll-in">※1 調査には、治療費・食事代・差額ベッド代に加え、交通費（見舞いに来る家族の交通費を含む）や衣類、日用品などを含む。高額療養費制度を利用した場合は利用後の金額</p>
           </div>
         </section>
-        <!--  社内確認中 -->
-        <!-- <section class="l-gan-hoken">
-          <div class="c-section-heading js-scroll-in">
-            <p class="c-section-heading__text">がん保険のピッタリは？</p>
-            <div class="c-section-heading__line"></div>
-            <div class="c-section-heading__arrow"></div>
-          </div>
-          <div class="c-detail-button c-detail-button--gan js-scroll-in">
-            <div class="c-detail-button__box">
-              <p class="c-detail-button__box-text">がん保険って必要</p>
-            </div>
-          </div>
-          <div class="l-gan-hoken__illust js-scroll-in">
-            <picture>
-              <source srcset="images/webp/illust_gan_person.webp" type="image/webp" width="292" height="239" />
-              <img src="images/illust_gan_person.png" alt="がん保険って必要男性女性イラスト" width="292" height="239" loading="lazy" />
-            </picture>
-          </div>
-          <div class="l-detail-content l-gan-hoken__detail">
-            <div class="l-detail-content__arrow"></div>
-            <div class="l-detail-content__outer">
-              <div class="l-detail-content__inner">
-                <p class="c-detail__heading js-scroll-in">
-                  <span class="c-detail__heading-strong">2人に1人</span>が一生涯のうちに<br />
-                  「がん」と診断されています！
-                </p>
-                <div class="l-gan-data">
-                  <div class="l-gan-data__person-wrapper">
-                    <div class="l-gan-data__person l-gan-data__person--man js-anim">
-                      <div class="l-gan-data__person-illust">
-                        <div class="l-gan-data__person-illust-base">
-                          <picture>
-                            <source srcset="images/webp/illust_man_base.webp" type="image/webp" width="133" height="355" />
-                            <img src="images/illust_man_base.png" alt="がん率男性イラスト" width="133" height="355" loading="lazy" />
-                          </picture>
-                        </div>
-                        <div class="l-gan-data__person-illust-cover">
-                          <picture>
-                            <source srcset="images/webp/illust_man_cover.webp" type="image/webp" width="133" height="233" />
-                            <img src="images/illust_man_cover.png" alt="がん率男性イラスト" width="133" height="233" loading="lazy" />
-                          </picture>
-                        </div>
-                      </div>
-                      <p class="l-gan-data__person-rate l-gan-data__person-rate--man"><span class="font-roboto">65.5</span><span class="l-gan-data__person-rate-value">%</span></p>
-                    </div>
-                    <div class="l-gan-data__person l-gan-data__person--woman js-anim">
-                      <div class="l-gan-data__person-illust">
-                        <div class="l-gan-data__person-illust-base">
-                          <picture>
-                            <source srcset="images/webp/illust_woman_base.webp" type="image/webp" width="164" height="357" />
-                            <img src="images/illust_woman_base.png" alt="がん率女性イラスト本体" width="164" height="357" loading="lazy" />
-                          </picture>
-                        </div>
-                        <div class="l-gan-data__person-illust-cover">
-                          <picture>
-                            <source srcset="images/webp/illust_woman_cover.webp" type="image/webp" width="164" height="184" />
-                            <img src="images/illust_woman_cover.png" alt="がん率男性イラスト割合" width="164" height="184" loading="lazy" />
-                          </picture>
-                        </div>
-                      </div>
-                      <p class="l-gan-data__person-rate l-gan-data__person-rate--woman"><span class="font-roboto">51.2</span><span class="l-gan-data__person-rate-value">%</span></p>
-                    </div>
-                  </div>
-                  <p class="c-detail-attention js-scroll-in">(公財)がん研究振興財団｢がんの統計2023｣年齢階級別罹患リスク(2019年罹患・死亡データに基づく)全がん</p>
-                </div>
-                <p class="c-detail__heading js-scroll-in">がんの治療方法は<span class="c-detail__heading-strong">多様化</span></p>
-                <div class="l-gan-howto js-scroll-in">
-                  <p class="l-gan-howto__heading">がんの三大治療</p>
-                  <ul class="l-gan-howto__list">
-                    <li class="l-gan-howto__list-image">
-                      <picture>
-                        <source srcset="images/webp/illust_koganzai.webp" type="image/webp" width="150" height="150" />
-                        <img src="images/illust_koganzai.png" alt="抗がん剤" width="150" height="150" loading="lazy" />
-                      </picture>
-                    </li>
-                    <li class="l-gan-howto__list-image">
-                      <picture>
-                        <source srcset="images/webp/illust_hoshasen.webp" type="image/webp" width="150" height="150" />
-                        <img src="images/illust_hoshasen.png" alt="放射線" width="150" height="150" loading="lazy" />
-                      </picture>
-                    </li>
-                    <li class="l-gan-howto__list-image">
-                      <picture>
-                        <source srcset="images/webp/illust_shujyutsu.webp" type="image/webp" width="150" height="150" />
-                        <img src="images/illust_shujyutsu.png" alt="放射線" width="150" height="150" loading="lazy" />
-                      </picture>
-                    </li>
-                  </ul>
-                </div>
-                <div class="c-detail-arrow js-scroll-in">
-                  <picture>
-                    <source srcset="images/webp/icon_arrow_blue.webp" type="image/webp" width="320" height="70" />
-                    <img src="images/icon_arrow_blue.png" alt="下向き矢印" width="320" height="70" loading="lazy" />
-                  </picture>
-                </div>
-                <p class="c-detail__heading js-scroll-in">
-                  治療方法に縛られず<br />
-                  <span class="c-detail__heading-strong">使い方自由</span>な一時金
-                </p>
-                <div class="l-money js-scroll-in">
-                  <div class="l-money__figure">
-                    <div class="l-money__figure-track">
-                      <div class="l-money__figure-track-illust">
-                        <picture>
-                          <source srcset="images/webp/illust_track.webp" type="image/webp" width="594" height="270" />
-                          <img src="images/illust_track.png" alt="一時金のサイクル図" width="594" height="270" loading="lazy" />
-                        </picture>
-                      </div>
-                      <div class="l-money__figure-track-arrow l-money__figure-track-arrow--top">
-                        <div class="l-money__figure-track-arrow-elm l-money__figure-track-arrow-elm--top">
-                          <picture>
-                            <source srcset="images/webp/icon_arrow_top.webp" type="image/webp" width="53" height="64" />
-                            <img src="images/icon_arrow_top.png" alt="右向き矢印" width="53" height="64" loading="lazy" />
-                          </picture>
-                        </div>
-                        <div class="l-money__figure-track-arrow-elm l-money__figure-track-arrow-elm--top">
-                          <picture>
-                            <source srcset="images/webp/icon_arrow_top.webp" type="image/webp" width="53" height="64" />
-                            <img src="images/icon_arrow_top.png" alt="右向き矢印" width="53" height="64" loading="lazy" />
-                          </picture>
-                        </div>
-                      </div>
-                      <div class="l-money__figure-track-arrow l-money__figure-track-arrow--bottom">
-                        <div class="l-money__figure-track-arrow-elm l-money__figure-track-arrow-elm--bottom">
-                          <picture>
-                            <source srcset="images/webp/icon_arrow_btm.webp" type="image/webp" width="53" height="49" />
-                            <img src="images/icon_arrow_btm.png" alt="右向き矢印" width="53" height="49" loading="lazy" />
-                          </picture>
-                        </div>
-                        <div class="l-money__figure-track-arrow-elm l-money__figure-track-arrow-elm--bottom">
-                          <picture>
-                            <source srcset="images/webp/icon_arrow_btm.webp" type="image/webp" width="53" height="49" />
-                            <img src="images/icon_arrow_btm.png" alt="右向き矢印" width="53" height="49" loading="lazy" />
-                          </picture>
-                        </div>
-                      </div>
-                    </div>
-                    <div class="l-money__headline">
-                      <div class="l-money__headline-icon">
-                        <p class="l-money__headline-icon-pop">
-                          <picture>
-                            <source srcset="images/webp/pop_money.webp" type="image/webp" width="174" height="80" />
-                            <img src="images/pop_money.png" alt="100万円" width="174" height="80" loading="lazy" />
-                          </picture>
-                        </p>
-                        <div class="l-money__headline-icon-image">
-                          <picture>
-                            <source srcset="images/webp/illust_money.webp" type="image/webp" width="101" height="106" />
-                            <img src="images/illust_money.png" alt="お金のアイコン" width="101" height="106" loading="lazy" />
-                          </picture>
-                        </div>
-                      </div>
-                      <p class="l-money__headline-heading">
-                        繰り返し<br />
-                        <span class="l-money__headline-heading-color">何度</span>も受け取り!<sup class="l-gan-money__headline-heading-mark">*</sup>
-                      </p>
-                    </div>
-                  </div>
-                </div>
-                <p class="c-detail-attention js-scroll-in">＊ご案内する商品によって繰り返しもらえる回数や受取期間は異なります。申込みの際にご確認ください。</p>
-                <div class="l-gan-tsuin">
-                  <p class="l-gan__tsuin-heading js-scroll-in">さらに</p>
-                  <div class="l-gan-tsuin__inner">
-                    <p class="c-detail__heading js-scroll-in">
-                      がん治療は<br />
-                      <span class="c-detail__heading-strong">通院</span>が増えています！
-                    </p>
-                    <div class="l-line-graph">
-                      <div class="l-line-graph__figure">
-                        <div class="l-line-graph__base">
-                          <picture>
-                            <source srcset="images/webp/graph_line.webp" type="image/webp" width="568" height="381" />
-                            <img src="images/graph_line.png" alt="社会医療診療行為別統計(各年6月審査分)の折れ線グラフ" width="568" height="381" />
-                          </picture>
-                        </div>
-                        <div class="l-line-graph__rate js-anim">
-                          <div class="l-line-graph__rate-circle l-line-graph__rate-circle--circle1"></div>
-                          <div class="l-line-graph__rate-line l-line-graph__rate-line--long l-line-graph__rate-line--line1"></div>
-                          <div class="l-line-graph__rate-circle l-line-graph__rate-circle--circle2"></div>
-                          <div class="l-line-graph__rate-line l-line-graph__rate-line--line2"></div>
-                          <div class="l-line-graph__rate-circle l-line-graph__rate-circle--circle3"></div>
-                          <div class="l-line-graph__rate-line l-line-graph__rate-line--line3"></div>
-                          <div class="l-line-graph__rate-circle l-line-graph__rate-circle--circle4"></div>
-                          <div class="l-line-graph__rate-line l-line-graph__rate-line--line4"></div>
-                          <div class="l-line-graph__rate-circle l-line-graph__rate-circle--circle5"></div>
-                          <div class="l-line-graph__rate-line l-line-graph__rate-line--line5"></div>
-                          <div class="l-line-graph__rate-circle l-line-graph__rate-circle--circle6"></div>
-                          <div class="l-line-graph__rate-line l-line-graph__rate-line--line6"></div>
-                          <div class="l-line-graph__rate-circle l-line-graph__rate-circle--circle7"></div>
-                          <div class="l-line-graph__rate-line l-line-graph__rate-line--line7"></div>
-                        </div>
-                      </div>
-                      <p class="c-detail-attention c-detail-attention--line-graph">社会医療診療行為別統計(各年6月審査分)</p>
-                    </div>
-                    <div class="c-detail-arrow js-scroll-in">
-                      <picture>
-                        <source srcset="images/webp/icon_arrow_blue.webp" type="image/webp" width="320" height="70" />
-                        <img src="images/icon_arrow_blue.png" alt="下向き矢印" width="320" height="70" loading="lazy" />
-                      </picture>
-                    </div>
-                    <p class="c-detail__heading js-scroll-in">
-                      がん治療の<span class="c-detail__heading-strong">長期化</span>に備え<br />
-                      治療した月ごとの備えを*
-                    </p>
-                    <div class="l-term">
-                      <div class="l-term__figure js-scroll-in">
-                        <picture>
-                          <source srcset="images/webp/graph_term.webp" type="image/webp" width="645" height="281" />
-                          <img src="images/graph_term.png" alt="治療の流れのグラフ" width="645" height="281" />
-                        </picture>
-                      </div>
-                      <p class="c-detail-attention js-scroll-in">＊ご案内する商品・プランによって繰り返しもらえる回数や金額、対象となる治療方法が異なります。申込みの際にご確認ください。</p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section> -->
-        <!-- /社内確認中 -->
         <section class="l-interview">
           <div class="c-section-heading js-scroll-in">
             <p class="c-section-heading__text">オンライン面談の手順</p>
@@ -1129,7 +909,7 @@
             恵比寿ビジネスタワー 16F
           </p>
         </div>
-        <p class="l-footer__number">承認番号：xxxxx</p>
+        <p class="l-footer__number">承認番号：D50157</p>
         <p class="l-footer__copyright">&copy; FINANCIAL AGENCY, Inc.</p>
       </footer>
       <div role="dialog" id="modal" aria-hidden="true" class="l-modal" aria-labelledby="modalHeading" aria-describedby="modalDescription">


### PR DESCRIPTION
## 実装内容

- がん保険レイアウト コメントアウトで残す
- 承認番号追加
- テキスト修正
- ogp削除

## 該当画面URL

https://www.financial-agency.com/service/fp/date/100××××/

## 共有事項

がん保険の内容確認に時間が必要のため、3月頭リリースには間に合わないということで今回の公開の段階では非表示という方向になりました。今後、内容の確認が取れ次第反映する予定です！

がん保険のレイアウトはコメントアウトで残しています。

## 残タスク

ありません。